### PR TITLE
Updating to handle repeat notifications

### DIFF
--- a/ipn.php
+++ b/ipn.php
@@ -468,12 +468,12 @@ class uk_co_circleinteractive_payment_sagepay_notify extends CRM_Core_Payment_Ba
         // If we arrived here, Status = OK
         
         // Check if contribution is already complete, if so ignore this ipn
-        //if ($contribution->contribution_status_id == 1) {
-        //    $transaction->commit();
-        //    CRM_Core_Error::debug_log_message("returning since contribution has already been handled");
-        //    echo "Success: Contribution has already been handled";
-        //    return true;
-        //}
+        if ($contribution->contribution_status_id == 1) {
+            $transaction->commit();
+            CRM_Core_Error::debug_log_message("returning since contribution has already been handled");
+            echo "Success: Contribution has already been handled";
+            return true;
+        }
         
         $this->completeTransaction($input, $ids, $objects, $transaction, $recur);
 


### PR DESCRIPTION
At the moment the Payment Processor doesn't seem to handle SagePay sending 10 repeat notifications, 1 a second, if it doesn't get an OK response quickly enough.

I saw there was already a commented-out section which appeared to deal with this (similar to the CiviCRM Wiki page on Payment Processors) and have re-enabled.