### PR TITLE
Split method DEPRECATED in PHP 5.3.0, and REMOVED in PHP 7.0.0.

### DIFF
--- a/custom/php/CRM/Core/Payment/Sagepay.php
+++ b/custom/php/CRM/Core/Payment/Sagepay.php
@@ -512,7 +512,7 @@ class CRM_Core_Payment_Sagepay extends CRM_Core_Payment {
         ]);
 
         // Send request and split response into name/value pairs
-        $response = split(chr(10), curl_exec($session));
+        $response = preg_split('/' . chr(10) . '/', curl_exec($session));
 
         // Check that a connection was made
         if (curl_error($session)){


### PR DESCRIPTION
http://php.net/manual/en/function.split.php

Using preg_split instead.